### PR TITLE
アクセス制限実装

### DIFF
--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -14,7 +14,7 @@ form#edit_proposer {
 
   .box1 {
     width: 350px;
-    height: 600px;
+    max-height: 800px;
     margin: 60px auto 0;
     border-radius: 4px;
     border: 1px #ddd solid;

--- a/app/controllers/outfits_controller.rb
+++ b/app/controllers/outfits_controller.rb
@@ -1,6 +1,7 @@
 class OutfitsController < ApplicationController
-  before_action :authenticate_proposer!, only: %i[ index new create edit update destroy]
-  before_action :authenticate_user!
+  #before_action :authenticate_proposer!, only: %i[ index new create edit update destroy]
+  #before_action :authenticate_user!
+  before_action :authenticate_user_proposer, only: %i[index]
   before_action :set_outfit, only: [:show, :edit, :update, :destroy]
   
 
@@ -67,5 +68,11 @@ class OutfitsController < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def outfit_params
       params.require(:outfit).permit(:title, :content, :image).merge(proposer_id: current_proposer.id)
+    end
+
+    def authenticate_user_proposer
+      if current_user.nil? && current_proposer.nil?
+        redirect_to  new_user_session_path
+      end
     end
 end


### PR DESCRIPTION
ログインせずに投稿一覧にurlベタうちで行けないよう制御
新規登録項目入力せずに登録を押すと要素が枠をはみ出す問題解消